### PR TITLE
Update MockData to be able to build Mocks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ Style/Documentation:
   Enabled: false
 Metrics/BlockLength:
   Max: 150
-Layout/LineLength:
+Metrics/LineLength:
   Max: 100
 Style/WordArray:
   Enabled: false

--- a/data/mock_data.rb
+++ b/data/mock_data.rb
@@ -1,7 +1,10 @@
 require 'Date'
 
-class MockData
+module ItemMock
 
+end
+
+class MockData
   def self.get_a_random_date(random = true)
     if random
       date_s = "20#{rand(10..21)}-#{rand(1..12)}-#{rand(1..28)}"
@@ -13,6 +16,24 @@ class MockData
 
   def self.get_a_random_price
     (rand(1..120) + (rand(100) / 100.0))
+  end
+
+  def self.merchants_as_mocks(merchant_hashes)
+    mocked_merchants = []
+
+    merchant_hashes.each do |merchant_hash|
+      raise 'Bind self of ExampleGroup to your mocks. use {self}' if not block_given?
+      eg = yield
+      merchant_mock = eg.instance_double('Merchant Mock')
+      eg.allow(merchant_mock).to eg.receive(:name).and_return(merchant_hash[:name])
+      eg.allow(merchant_mock).to eg.receive(:id).and_return(merchant_hash[:id])
+
+      eg.allow(merchant_mock).to eg.receive(:created_at).and_return(merchant_hash[:created_at])
+      eg.allow(merchant_mock).to eg.receive(:updated_at).and_return(merchant_hash[:updated_at])
+
+      mocked_merchants << merchant_mock
+    end
+    mocked_merchants
   end
 
   def self.merchants_as_hash(number_of_mocks: 10, random_dates: true)
@@ -33,6 +54,32 @@ class MockData
       mocked_merchants << merchant
     end
     mocked_merchants
+  end
+
+  def self.items_as_mocks(number_of_mocks: 10, number_of_merchants: 2, random_dates: true, price_of: 0)
+    mocked_items = []
+    item_hashes = items_as_hash(number_of_mocks: number_of_mocks,
+                                number_of_merchants: number_of_merchants,
+                                random_dates: random_dates,
+                                price_of: price_of)
+    item_hashes.each do |item_hash|
+      raise 'Bind self of ExampleGroup to your mocks. use {self}' if not block_given?
+      eg = yield
+      item = eg.instance_double('Item Mock')
+      eg.allow(item).to eg.receive(:name).and_return(item_hash[:name])
+      eg.allow(item).to eg.receive(:id).and_return(item_hash[:id])
+
+      eg.allow(item).to eg.receive(:unit_price).and_return(item_hash[:unit_price])
+
+      eg.allow(item).to eg.receive(:description).and_return(item_hash[:description])
+      eg.allow(item).to eg.receive(:merchant_id).and_return(item_hash[:merchant_id])
+
+      eg.allow(item).to eg.receive(:created_at).and_return(item_hash[:created_at])
+      eg.allow(item).to eg.receive(:updated_at).and_return(item_hash[:updated_at])
+
+      mocked_items << item
+    end
+    mocked_items
   end
 
   def self.items_as_hash(number_of_mocks: 10, number_of_merchants: 2, random_dates: true, price_of: 0)
@@ -56,7 +103,6 @@ class MockData
         item[:created_at] = date.prev_year.to_s
         item[:updated_at] = date.to_s
       end
-      item[:updated_at] = date.to_s
       mocked_items << item
     end
     mocked_items
@@ -69,7 +115,7 @@ class MockData
   end
 
   def self.mean_of_item_prices(items)
-    sum = sum_prices(items)
+    sum = sum_item_prices(items)
     (sum / items.length)
   end
 end

--- a/data/mock_data.rb
+++ b/data/mock_data.rb
@@ -15,7 +15,7 @@ class MockData
     (rand(1..120) + (rand(100) / 100.0))
   end
 
-  def self.get_mock_merchants(number_of_mocks: 10, random_dates: true)
+  def self.merchants_as_hash(number_of_mocks: 10, random_dates: true)
     mocked_merchants = []
     number_of_mocks.times do |merchant_number|
       merchant = {}
@@ -35,7 +35,7 @@ class MockData
     mocked_merchants
   end
 
-  def self.get_mock_items(number_of_mocks: 10, number_of_merchants: 2, random_dates: true, price_of: 0)
+  def self.items_as_hash(number_of_mocks: 10, number_of_merchants: 2, random_dates: true, price_of: 0)
     mocked_items = []
     number_of_mocks.times do |item_number|
       item = {}
@@ -62,13 +62,13 @@ class MockData
     mocked_items
   end
 
-  def self.sum_prices(items)
+  def self.sum_item_prices(items)
     items.sum do |item|
       item[:unit_price]
     end
   end
 
-  def self.mean_price(items)
+  def self.mean_of_item_prices(items)
     sum = sum_prices(items)
     (sum / items.length)
   end

--- a/data/mock_data.rb
+++ b/data/mock_data.rb
@@ -1,9 +1,5 @@
 require 'Date'
 
-module ItemMock
-
-end
-
 class MockData
   def self.get_a_random_date(random = true)
     if random

--- a/data/mock_data.rb
+++ b/data/mock_data.rb
@@ -20,13 +20,12 @@ class MockData
     merchant_hashes.each do |merchant_hash|
       raise 'Bind self of ExampleGroup to your mocks. use {self}' if not block_given?
       eg = yield
-      merchant_mock = eg.instance_double('Merchant Mock')
-      eg.allow(merchant_mock).to eg.receive(:name).and_return(merchant_hash[:name])
-      eg.allow(merchant_mock).to eg.receive(:id).and_return(merchant_hash[:id])
-
-      eg.allow(merchant_mock).to eg.receive(:created_at).and_return(merchant_hash[:created_at])
-      eg.allow(merchant_mock).to eg.receive(:updated_at).and_return(merchant_hash[:updated_at])
-
+      merchant_mock = eg.instance_double('Merchant',
+        name: item_hash[:name],
+        id: item_hash[:id],
+        created_at: item_hash[:created_at],
+        updated_at: item_hash[:updated_at]
+      )
       mocked_merchants << merchant_mock
     end
     mocked_merchants
@@ -57,18 +56,15 @@ class MockData
     item_hashes.each do |item_hash|
       raise 'Bind self of ExampleGroup to your mocks. use {self}' if not block_given?
       eg = yield
-      item = eg.instance_double('Item Mock')
-      eg.allow(item).to eg.receive(:name).and_return(item_hash[:name])
-      eg.allow(item).to eg.receive(:id).and_return(item_hash[:id])
-
-      eg.allow(item).to eg.receive(:unit_price).and_return(item_hash[:unit_price])
-
-      eg.allow(item).to eg.receive(:description).and_return(item_hash[:description])
-      eg.allow(item).to eg.receive(:merchant_id).and_return(item_hash[:merchant_id])
-
-      eg.allow(item).to eg.receive(:created_at).and_return(item_hash[:created_at])
-      eg.allow(item).to eg.receive(:updated_at).and_return(item_hash[:updated_at])
-
+      item = eg.instance_double('Item',
+        name: item_hash[:name],
+        id: item_hash[:id],
+        unit_price: item_hash[:unit_price],
+        description: item_hash[:description],
+        merchant_id: item_hash[:merchant_id],
+        created_at: item_hash[:created_at],
+        updated_at: item_hash[:updated_at]
+      )
       mocked_items << item
     end
     mocked_items

--- a/data/mock_data.rb
+++ b/data/mock_data.rb
@@ -56,12 +56,8 @@ class MockData
     mocked_merchants
   end
 
-  def self.items_as_mocks(number_of_mocks: 10, number_of_merchants: 2, random_dates: true, price_of: 0)
+  def self.items_as_mocks(item_hashes)
     mocked_items = []
-    item_hashes = items_as_hash(number_of_mocks: number_of_mocks,
-                                number_of_merchants: number_of_merchants,
-                                random_dates: random_dates,
-                                price_of: price_of)
     item_hashes.each do |item_hash|
       raise 'Bind self of ExampleGroup to your mocks. use {self}' if not block_given?
       eg = yield
@@ -108,14 +104,14 @@ class MockData
     mocked_items
   end
 
-  def self.sum_item_prices(items)
+  def self.sum_item_prices_from_hash(items)
     items.sum do |item|
       item[:unit_price]
     end
   end
 
-  def self.mean_of_item_prices(items)
-    sum = sum_item_prices(items)
+  def self.mean_of_item_prices_from_hash(items)
+    sum = sum_item_prices_from_hash(items)
     (sum / items.length)
   end
 end

--- a/spec/mock_data_spec.rb
+++ b/spec/mock_data_spec.rb
@@ -2,9 +2,31 @@ require 'rspec'
 require './data/mock_data'
 
 describe MockData do
+
+  describe '#merchants_as_mocks' do
+    it 'returns mock data as an array of mocks' do
+      merchant_hashs = MockData.merchants_as_hash
+      mocks = MockData.merchants_as_mocks(merchant_hashs) {self}
+
+      expect(mocks).to be_instance_of Array
+      expect(mocks.length).to eq 10
+    end
+
+    it 'returns mock data of merchants with data' do
+      merchant_hashs = MockData.merchants_as_hash(number_of_mocks: 2)
+      mocks = MockData.merchants_as_mocks(merchant_hashs) {self}
+      mocked_merchant = mocks.first
+      expect(mocks.length).to eq 2
+      expect(mocked_merchant.name).to eq 'Merchant 0'
+      expect(mocked_merchant.id).to eq 0
+      expect(mocked_merchant.created_at).to match /\d{4}-\d{2}-\d{2}/
+      expect(mocked_merchant.updated_at).to match /\d{4}-\d{2}-\d{2}/
+    end
+  end
+
   describe '#mechants_as_hash' do
     it 'returns mock data as an array of hashes' do
-      mocks = MockData.mechants_as_hash
+      mocks = MockData.merchants_as_hash {self}
 
       expect(mocks).to be_instance_of Array
       expect(mocks.length).to eq 10
@@ -12,13 +34,35 @@ describe MockData do
     end
 
     it 'returns mock data of merchants with data' do
-      mocks = MockData.mechants_as_hash(number_of_mocks: 2)
+      mocks = MockData.merchants_as_hash(number_of_mocks: 2)
       mocked_merchant = mocks.first
       expect(mocks.length).to eq 2
       expect(mocked_merchant[:name]).to eq 'Merchant 0'
       expect(mocked_merchant[:id]).to eq 0
       expect(mocked_merchant[:created_at]).to match /\d{4}-\d{2}-\d{2}/
       expect(mocked_merchant[:updated_at]).to match /\d{4}-\d{2}-\d{2}/
+    end
+  end
+
+  describe '#items_as_mocks' do
+    it 'returns mock items as an array of mocks' do
+      mocks = MockData.items_as_mocks {self}
+
+      expect(mocks).to be_instance_of Array
+      expect(mocks.length).to eq 10
+    end
+
+    it 'returns mock data of items with expected attributes' do
+      mocks = MockData.items_as_mocks(number_of_mocks: 2) {self}
+      mocked_item = mocks.first
+      expect(mocks.length).to eq 2
+      expect(mocked_item.name).to eq 'Item 0'
+      expect(mocked_item.id).to eq 0
+      expect(mocked_item.merchant_id).to be_instance_of Integer
+      expect(mocked_item.unit_price).to be_instance_of Float
+      expect(mocked_item.description).to eq 'Item Description'
+      expect(mocked_item.created_at).to match /\d{4}-\d{2}-\d{2}/
+      expect(mocked_item.updated_at).to match /\d{4}-\d{2}-\d{2}/
     end
   end
 

--- a/spec/mock_data_spec.rb
+++ b/spec/mock_data_spec.rb
@@ -2,9 +2,9 @@ require 'rspec'
 require './data/mock_data'
 
 describe MockData do
-  describe '#get_mock_merchants' do
+  describe '#mechants_as_hash' do
     it 'returns mock data as an array of hashes' do
-      mocks = MockData.get_mock_merchants
+      mocks = MockData.mechants_as_hash
 
       expect(mocks).to be_instance_of Array
       expect(mocks.length).to eq 10
@@ -12,7 +12,7 @@ describe MockData do
     end
 
     it 'returns mock data of merchants with data' do
-      mocks = MockData.get_mock_merchants(number_of_mocks: 2)
+      mocks = MockData.mechants_as_hash(number_of_mocks: 2)
       mocked_merchant = mocks.first
       expect(mocks.length).to eq 2
       expect(mocked_merchant[:name]).to eq 'Merchant 0'
@@ -22,17 +22,17 @@ describe MockData do
     end
   end
 
-  describe '#get_mock_items' do
+  describe '#items_as_hash' do
     it 'returns mock data as an array of hashes' do
-      mocks = MockData.get_mock_items
+      mocks = MockData.items_as_hash
 
       expect(mocks).to be_instance_of Array
       expect(mocks.length).to eq 10
       expect(mocks.first).to be_instance_of Hash
     end
 
-    it 'returns mock data of items with data' do
-      mocks = MockData.get_mock_items(number_of_mocks: 2)
+    it 'returns mock data of items with expected attributes' do
+      mocks = MockData.items_as_hash(number_of_mocks: 2)
       mocked_item = mocks.first
       expect(mocks.length).to eq 2
       expect(mocked_item[:name]).to eq 'Item 0'
@@ -64,22 +64,22 @@ describe MockData do
     end
   end
 
-  describe '#sum_prices' do
+  describe '#sum_item_prices' do
     it 'sums prices' do
       allow(MockData).to receive(:get_a_random_price).and_return(1)
-      mock_items = MockData.get_mock_items
+      mock_items = MockData.items_as_hash
       expected_sum = 10
-      actual_sum = MockData.sum_prices(mock_items)
+      actual_sum = MockData.sum_item_prices(mock_items)
       expect(actual_sum).to eq expected_sum
     end
   end
 
-  describe '#mean_price' do
-    it 'sums prices' do
+  describe '#mean_of_item_prices' do
+    it 'gets the mean value of item prices' do
       allow(MockData).to receive(:get_a_random_price).and_return(5)
-      mock_items = MockData.get_mock_items
+      mock_items = MockData.items_as_hash
       expected_mean = 5
-      actual_mean = MockData.mean_price(mock_items)
+      actual_mean = MockData.mean_of_item_prices(mock_items)
       expect(actual_mean).to eq expected_mean
     end
   end

--- a/spec/mock_data_spec.rb
+++ b/spec/mock_data_spec.rb
@@ -89,6 +89,12 @@ describe MockData do
       expect(first_item_hash[:created_at]).to match /\d{4}-\d{2}-\d{2}/
       expect(first_item_hash[:updated_at]).to match /\d{4}-\d{2}-\d{2}/
     end
+    it 'returns mock data of items with given number_of_merchants' do
+      items_as_hash = MockData.items_as_hash(number_of_mocks: 2, number_of_merchants: 1)
+      
+      expect(items_as_hash.first[:merchant_id]).to eq 0
+      expect(items_as_hash.last[:merchant_id]).to eq 0
+    end
   end
 
   describe '#get_a_random_price' do

--- a/spec/mock_data_spec.rb
+++ b/spec/mock_data_spec.rb
@@ -2,11 +2,10 @@ require 'rspec'
 require './data/mock_data'
 
 describe MockData do
-
   describe '#merchants_as_mocks' do
     it 'returns mock data as an array of mocks' do
       merchant_hashs = MockData.merchants_as_hash
-      merchants_as_mocks = MockData.merchants_as_mocks(merchant_hashs) {self}
+      merchants_as_mocks = MockData.merchants_as_mocks(merchant_hashs) { self }
 
       expect(merchants_as_mocks).to be_instance_of Array
       expect(merchants_as_mocks.length).to eq 10
@@ -14,19 +13,19 @@ describe MockData do
 
     it 'returns mock data of merchants with data' do
       merchant_hashs = MockData.merchants_as_hash(number_of_mocks: 2)
-      merchants_as_mocks = MockData.merchants_as_mocks(merchant_hashs) {self}
+      merchants_as_mocks = MockData.merchants_as_mocks(merchant_hashs) { self }
       mocked_merchant = merchants_as_mocks.first
       expect(merchants_as_mocks.length).to eq 2
       expect(mocked_merchant.name).to eq 'Merchant 0'
       expect(mocked_merchant.id).to eq 0
-      expect(mocked_merchant.created_at).to match /\d{4}-\d{2}-\d{2}/
-      expect(mocked_merchant.updated_at).to match /\d{4}-\d{2}-\d{2}/
+      expect(mocked_merchant.created_at).to match(/\d{4}-\d{2}-\d{2}/)
+      expect(mocked_merchant.updated_at).to match(/\d{4}-\d{2}-\d{2}/)
     end
   end
 
   describe '#mechants_as_hash' do
     it 'returns mock data as an array of hashes' do
-      merchants_as_hash = MockData.merchants_as_hash {self}
+      merchants_as_hash = MockData.merchants_as_hash { self }
 
       expect(merchants_as_hash).to be_instance_of Array
       expect(merchants_as_hash.length).to eq 10
@@ -39,15 +38,15 @@ describe MockData do
       expect(mocked_hash_data.length).to eq 2
       expect(mocked_merchant[:name]).to eq 'Merchant 0'
       expect(mocked_merchant[:id]).to eq 0
-      expect(mocked_merchant[:created_at]).to match /\d{4}-\d{2}-\d{2}/
-      expect(mocked_merchant[:updated_at]).to match /\d{4}-\d{2}-\d{2}/
+      expect(mocked_merchant[:created_at]).to match(/\d{4}-\d{2}-\d{2}/)
+      expect(mocked_merchant[:updated_at]).to match(/\d{4}-\d{2}-\d{2}/)
     end
   end
 
   describe '#items_as_mocks' do
     it 'returns mock items as an array of mocks' do
       items_as_hash = MockData.items_as_hash
-      items_as_mocks = MockData.items_as_mocks (items_as_hash) {self}
+      items_as_mocks = MockData.items_as_mocks(items_as_hash) { self }
 
       expect(items_as_mocks).to be_instance_of Array
       expect(items_as_mocks.length).to eq 10
@@ -55,7 +54,7 @@ describe MockData do
 
     it 'returns mock data of items with expected attributes' do
       items_as_hash = MockData.items_as_hash(number_of_mocks: 2)
-      mocks = MockData.items_as_mocks(items_as_hash) {self}
+      mocks = MockData.items_as_mocks(items_as_hash) { self }
       mocked_item = mocks.first
       expect(mocks.length).to eq 2
       expect(mocked_item.name).to eq 'Item 0'
@@ -63,8 +62,8 @@ describe MockData do
       expect(mocked_item.merchant_id).to be_instance_of Integer
       expect(mocked_item.unit_price).to be_instance_of Float
       expect(mocked_item.description).to eq 'Item Description'
-      expect(mocked_item.created_at).to match /\d{4}-\d{2}-\d{2}/
-      expect(mocked_item.updated_at).to match /\d{4}-\d{2}-\d{2}/
+      expect(mocked_item.created_at).to match(/\d{4}-\d{2}-\d{2}/)
+      expect(mocked_item.updated_at).to match(/\d{4}-\d{2}-\d{2}/)
     end
   end
 
@@ -86,12 +85,12 @@ describe MockData do
       expect(first_item_hash[:merchant_id]).to be_instance_of Integer
       expect(first_item_hash[:unit_price]).to be_instance_of Float
       expect(first_item_hash[:description]).to eq 'Item Description'
-      expect(first_item_hash[:created_at]).to match /\d{4}-\d{2}-\d{2}/
-      expect(first_item_hash[:updated_at]).to match /\d{4}-\d{2}-\d{2}/
+      expect(first_item_hash[:created_at]).to match(/\d{4}-\d{2}-\d{2}/)
+      expect(first_item_hash[:updated_at]).to match(/\d{4}-\d{2}-\d{2}/)
     end
     it 'returns mock data of items with given number_of_merchants' do
       items_as_hash = MockData.items_as_hash(number_of_mocks: 2, number_of_merchants: 1)
-      
+
       expect(items_as_hash.first[:merchant_id]).to eq 0
       expect(items_as_hash.last[:merchant_id]).to eq 0
     end
@@ -107,7 +106,7 @@ describe MockData do
   describe '#get_a_random_date' do
     it 'gets a random date with expected format' do
       date = MockData.get_a_random_date
-      expect(date.to_s).to match /\d{4}-\d{2}-\d{2}/
+      expect(date.to_s).to match(/\d{4}-\d{2}-\d{2}/)
     end
     it 'gets a non-random date' do
       first_date = MockData.get_a_random_date false

--- a/spec/mock_data_spec.rb
+++ b/spec/mock_data_spec.rb
@@ -6,17 +6,17 @@ describe MockData do
   describe '#merchants_as_mocks' do
     it 'returns mock data as an array of mocks' do
       merchant_hashs = MockData.merchants_as_hash
-      mocks = MockData.merchants_as_mocks(merchant_hashs) {self}
+      merchants_as_mocks = MockData.merchants_as_mocks(merchant_hashs) {self}
 
-      expect(mocks).to be_instance_of Array
-      expect(mocks.length).to eq 10
+      expect(merchants_as_mocks).to be_instance_of Array
+      expect(merchants_as_mocks.length).to eq 10
     end
 
     it 'returns mock data of merchants with data' do
       merchant_hashs = MockData.merchants_as_hash(number_of_mocks: 2)
-      mocks = MockData.merchants_as_mocks(merchant_hashs) {self}
-      mocked_merchant = mocks.first
-      expect(mocks.length).to eq 2
+      merchants_as_mocks = MockData.merchants_as_mocks(merchant_hashs) {self}
+      mocked_merchant = merchants_as_mocks.first
+      expect(merchants_as_mocks.length).to eq 2
       expect(mocked_merchant.name).to eq 'Merchant 0'
       expect(mocked_merchant.id).to eq 0
       expect(mocked_merchant.created_at).to match /\d{4}-\d{2}-\d{2}/
@@ -26,17 +26,17 @@ describe MockData do
 
   describe '#mechants_as_hash' do
     it 'returns mock data as an array of hashes' do
-      mocks = MockData.merchants_as_hash {self}
+      merchants_as_hash = MockData.merchants_as_hash {self}
 
-      expect(mocks).to be_instance_of Array
-      expect(mocks.length).to eq 10
-      expect(mocks.first).to be_instance_of Hash
+      expect(merchants_as_hash).to be_instance_of Array
+      expect(merchants_as_hash.length).to eq 10
+      expect(merchants_as_hash.first).to be_instance_of Hash
     end
 
     it 'returns mock data of merchants with data' do
-      mocks = MockData.merchants_as_hash(number_of_mocks: 2)
-      mocked_merchant = mocks.first
-      expect(mocks.length).to eq 2
+      mocked_hash_data = MockData.merchants_as_hash(number_of_mocks: 2)
+      mocked_merchant = mocked_hash_data.first
+      expect(mocked_hash_data.length).to eq 2
       expect(mocked_merchant[:name]).to eq 'Merchant 0'
       expect(mocked_merchant[:id]).to eq 0
       expect(mocked_merchant[:created_at]).to match /\d{4}-\d{2}-\d{2}/
@@ -46,14 +46,16 @@ describe MockData do
 
   describe '#items_as_mocks' do
     it 'returns mock items as an array of mocks' do
-      mocks = MockData.items_as_mocks {self}
+      items_as_hash = MockData.items_as_hash
+      items_as_mocks = MockData.items_as_mocks (items_as_hash) {self}
 
-      expect(mocks).to be_instance_of Array
-      expect(mocks.length).to eq 10
+      expect(items_as_mocks).to be_instance_of Array
+      expect(items_as_mocks.length).to eq 10
     end
 
     it 'returns mock data of items with expected attributes' do
-      mocks = MockData.items_as_mocks(number_of_mocks: 2) {self}
+      items_as_hash = MockData.items_as_hash(number_of_mocks: 2)
+      mocks = MockData.items_as_mocks(items_as_hash) {self}
       mocked_item = mocks.first
       expect(mocks.length).to eq 2
       expect(mocked_item.name).to eq 'Item 0'
@@ -68,24 +70,24 @@ describe MockData do
 
   describe '#items_as_hash' do
     it 'returns mock data as an array of hashes' do
-      mocks = MockData.items_as_hash
+      items_as_hash = MockData.items_as_hash
 
-      expect(mocks).to be_instance_of Array
-      expect(mocks.length).to eq 10
-      expect(mocks.first).to be_instance_of Hash
+      expect(items_as_hash).to be_instance_of Array
+      expect(items_as_hash.length).to eq 10
+      expect(items_as_hash.first).to be_instance_of Hash
     end
 
     it 'returns mock data of items with expected attributes' do
-      mocks = MockData.items_as_hash(number_of_mocks: 2)
-      mocked_item = mocks.first
-      expect(mocks.length).to eq 2
-      expect(mocked_item[:name]).to eq 'Item 0'
-      expect(mocked_item[:id]).to eq 0
-      expect(mocked_item[:merchant_id]).to be_instance_of Integer
-      expect(mocked_item[:unit_price]).to be_instance_of Float
-      expect(mocked_item[:description]).to eq 'Item Description'
-      expect(mocked_item[:created_at]).to match /\d{4}-\d{2}-\d{2}/
-      expect(mocked_item[:updated_at]).to match /\d{4}-\d{2}-\d{2}/
+      items_as_hash = MockData.items_as_hash(number_of_mocks: 2)
+      first_item_hash = items_as_hash.first
+      expect(items_as_hash.length).to eq 2
+      expect(first_item_hash[:name]).to eq 'Item 0'
+      expect(first_item_hash[:id]).to eq 0
+      expect(first_item_hash[:merchant_id]).to be_instance_of Integer
+      expect(first_item_hash[:unit_price]).to be_instance_of Float
+      expect(first_item_hash[:description]).to eq 'Item Description'
+      expect(first_item_hash[:created_at]).to match /\d{4}-\d{2}-\d{2}/
+      expect(first_item_hash[:updated_at]).to match /\d{4}-\d{2}-\d{2}/
     end
   end
 
@@ -108,22 +110,23 @@ describe MockData do
     end
   end
 
-  describe '#sum_item_prices' do
+  describe '#sum_item_prices_from_hash' do
     it 'sums prices' do
       allow(MockData).to receive(:get_a_random_price).and_return(1)
       mock_items = MockData.items_as_hash
       expected_sum = 10
-      actual_sum = MockData.sum_item_prices(mock_items)
+      actual_sum = MockData.sum_item_prices_from_hash(mock_items)
       expect(actual_sum).to eq expected_sum
     end
   end
 
-  describe '#mean_of_item_prices' do
+  describe '#mean_of_item_prices_from_hash' do
     it 'gets the mean value of item prices' do
       allow(MockData).to receive(:get_a_random_price).and_return(5)
+      allow(MockData).to receive(:sum_item_prices_from_hash).and_return(50)
       mock_items = MockData.items_as_hash
       expected_mean = 5
-      actual_mean = MockData.mean_of_item_prices(mock_items)
+      actual_mean = MockData.mean_of_item_prices_from_hash(mock_items)
       expect(actual_mean).to eq expected_mean
     end
   end


### PR DESCRIPTION
Implements a way to return mocked Items and Merchants

Invoking `items_as_mocks` or `merchants_as_mocks` must be done in a `describe` block or nested `it` block and it's imperative to bind the ExampleGroup of any test with `{self}` otherwise you will get an error message that will say `Bind self of ExampleGroup to your mocks. use {self}`
```rb
describe TestClass do
  it 'allows us to mock stuff' do
    items_data = MockData.items_as_hash # allows us to configure the test data
    item_mocks = MockData.items_as_mocks(items_data) {self}
    expect(item_mocks.first.name).to eq 'Item 0'
  end
end
```