### PR TITLE
Fix names

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,8 +17,6 @@ Style/SymbolProc:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
-Layout/SpaceBeforeBrackets: # (new in 1.7)
-  Enabled: true
 Lint/AmbiguousAssignment: # (new in 1.7)
   Enabled: true
 Lint/DeprecatedConstants: # (new in 1.8)

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,8 +17,6 @@ Style/SymbolProc:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
-Gemspec/DateAssignment: # (new in 1.10)
-  Enabled: true
 Layout/SpaceBeforeBrackets: # (new in 1.7)
   Enabled: true
 Lint/AmbiguousAssignment: # (new in 1.7)

--- a/data/mock_data.rb
+++ b/data/mock_data.rb
@@ -21,10 +21,10 @@ class MockData
       raise 'Bind self of ExampleGroup to your mocks. use {self}' if not block_given?
       eg = yield
       merchant_mock = eg.instance_double('Merchant',
-        name: item_hash[:name],
-        id: item_hash[:id],
-        created_at: item_hash[:created_at],
-        updated_at: item_hash[:updated_at]
+        name: merchant_hash[:name],
+        id: merchant_hash[:id],
+        created_at: merchant_hash[:created_at],
+        updated_at: merchant_hash[:updated_at]
       )
       mocked_merchants << merchant_mock
     end

--- a/lib/merchant.rb
+++ b/lib/merchant.rb
@@ -7,6 +7,8 @@ class Merchant
   def initialize(details)
     @id = details[:id]
     @name = details[:name]
+    @created_at = details[:created_at]
+    @updated_at = details[:updated_at]
   end
 
   def update_name(name)

--- a/lib/merchant.rb
+++ b/lib/merchant.rb
@@ -2,7 +2,9 @@
 
 class Merchant
   attr_reader :id,
-              :name
+              :name,
+              :created_at,
+              :updated_at
 
   def initialize(details)
     @id = details[:id]


### PR DESCRIPTION
Fixed names on hash in method merchants_as_mocks
Added attributes `updated_at` and `created_at` to Merchant class

Removed unrecognized Cop (not sure what it's not recognized anymore)
- [x] Tests are passing