### PR TITLE
Add tests for Item helper methods

### DIFF
--- a/lib/item.rb
+++ b/lib/item.rb
@@ -43,11 +43,13 @@ class Item
 
   def created_at
     return @created_at if @created_at.instance_of?(Time)
+
     Time.parse(@created_at)
   end
 
   def updated_at
     return @updated_at if @updated_at.instance_of?(Time)
+
     Time.parse(@updated_at)
   end
 end

--- a/lib/item.rb
+++ b/lib/item.rb
@@ -43,13 +43,11 @@ class Item
 
   def created_at
     return @created_at if @created_at.instance_of?(Time)
-
     Time.parse(@created_at)
   end
 
   def updated_at
     return @updated_at if @updated_at.instance_of?(Time)
-
     Time.parse(@updated_at)
   end
 end

--- a/spec/item_repository_spec.rb
+++ b/spec/item_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'rspec'
-
+require './data/item_mocks'
 require './data/mockable'
 require './lib/item'
 require './lib/item_repository'

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -120,4 +120,68 @@ describe Item do
       expect(item.id).not_to be_nil
     end
   end
+
+  describe '#updated_at' do
+    it 'returns updated_at time with String input' do
+      details = {
+        id: 1,
+        name: 'Pencil',
+        description: 'You can use it to write things',
+        unit_price: '2500',
+        created_at: '2007-06-04 21:35:10 UTC',
+        updated_at: '2007-06-04 21:35:10 UTC',
+        merchant_id: 2
+      }
+      item = Item.new(details)
+
+      expect(item.updated_at).to eq Time.parse('2007-06-04 21:35:10 UTC')
+    end
+
+    it 'returns updated_at time with Time input' do
+      details = {
+        id: 1,
+        name: 'Pencil',
+        description: 'You can use it to write things',
+        unit_price: '2500',
+        created_at: '2007-06-04 21:35:10 UTC',
+        updated_at: Time.parse('2007-06-04 21:35:10 UTC'),
+        merchant_id: 2
+      }
+      item = Item.new(details)
+
+      expect(item.updated_at).to eq Time.parse('2007-06-04 21:35:10 UTC')
+    end
+  end
+
+  describe '#created_at' do
+    it 'returns created_at time with String input' do
+      details = {
+        id: 1,
+        name: 'Pencil',
+        description: 'You can use it to write things',
+        unit_price: '2500',
+        created_at: '2007-06-04 21:35:10 UTC',
+        created_at: '2007-06-04 21:35:10 UTC',
+        merchant_id: 2
+      }
+      item = Item.new(details)
+
+      expect(item.created_at).to eq Time.parse('2007-06-04 21:35:10 UTC')
+    end
+
+    it 'returns created_at time with Time input' do
+      details = {
+        id: 1,
+        name: 'Pencil',
+        description: 'You can use it to write things',
+        unit_price: '2500',
+        created_at: Time.parse('2007-06-04 21:35:10 UTC'),
+        created_at: '2007-06-04 21:35:10 UTC',
+        merchant_id: 2
+      }
+      item = Item.new(details)
+
+      expect(item.created_at).to eq Time.parse('2007-06-04 21:35:10 UTC')
+    end
+  end
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -161,7 +161,7 @@ describe Item do
         description: 'You can use it to write things',
         unit_price: '2500',
         created_at: '2007-06-04 21:35:10 UTC',
-        created_at: '2007-06-04 21:35:10 UTC',
+        updated_at: '2007-06-04 21:35:10 UTC',
         merchant_id: 2
       }
       item = Item.new(details)
@@ -176,7 +176,7 @@ describe Item do
         description: 'You can use it to write things',
         unit_price: '2500',
         created_at: Time.parse('2007-06-04 21:35:10 UTC'),
-        created_at: '2007-06-04 21:35:10 UTC',
+        updated_at: '2007-06-04 21:35:10 UTC',
         merchant_id: 2
       }
       item = Item.new(details)

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -1,131 +1,56 @@
+require 'bigdecimal'
 require 'rspec'
+
 require './lib/item'
 
 describe Item do
   describe '#initialize' do
-    it 'exists' do
-      details = {
-        id: 1,
-        name: 'Pencil',
-        description: 'You can use it to write things',
-        unit_price: '1099',
-        created_at: Time.now,
-        updated_at: Time.now,
-        merchant_id: 2
-      }
-      item = Item.new(details)
+    details = {
+      id: 1,
+      name: 'Pencil',
+      description: 'You can use it to write things',
+      unit_price: '1099',
+      created_at: '2007-06-04 21:35:10 UTC',
+      updated_at: '2007-06-04 21:35:10 UTC',
+      merchant_id: 2
+    }
+    item = Item.new(details)
 
+    it 'exists' do
       expect(item).is_a? Item
     end
 
     it 'has an id' do
-      details = {
-        id: 1,
-        name: 'Pencil',
-        description: 'You can use it to write things',
-        unit_price: '1099',
-        created_at: Time.now,
-        updated_at: Time.now,
-        merchant_id: 2
-      }
-      item = Item.new(details)
-
       expect(item.id).to eq 1
       expect(item.id).is_a? Integer
     end
 
     it 'has a name' do
-      details = {
-        id: 1,
-        name: 'Pencil',
-        description: 'You can use it to write things',
-        unit_price: '1099',
-        created_at: Time.now,
-        updated_at: Time.now,
-        merchant_id: 2
-      }
-      item = Item.new(details)
-
       expect(item.name).to eq 'Pencil'
       expect(item.name).is_a? String
     end
 
     it 'has a description' do
-      details = {
-        id: 1,
-        name: 'Pencil',
-        description: 'You can use it to write things',
-        unit_price: '1099',
-        created_at: Time.now,
-        updated_at: Time.now,
-        merchant_id: 2
-      }
-      item = Item.new(details)
-
       expect(item.description).to eq 'You can use it to write things'
       expect(item.description).is_a? String
     end
 
     it 'has a unit price' do
-      details = {
-        id: 1,
-        name: 'Pencil',
-        description: 'You can use it to write things',
-        unit_price: '1099',
-        created_at: Time.now,
-        updated_at: Time.now,
-        merchant_id: 2
-      }
-      item = Item.new(details)
-
       expect(item.unit_price).to eq BigDecimal(10.99, 4)
       expect(item.unit_price).is_a? BigDecimal
     end
 
     it 'has a created_at Time' do
-      details = {
-        id: 1,
-        name: 'Pencil',
-        description: 'You can use it to write things',
-        unit_price: '1099',
-        created_at: '2007-06-04 21:35:10 UTC',
-        updated_at: '2007-06-04 21:35:10 UTC',
-        merchant_id: 2
-      }
-      item = Item.new(details)
-
       expect(item.created_at).to eq(Time.parse('2007-06-04 21:35:10 UTC'))
       expect(item.created_at).is_a? Time
     end
 
     it 'has a updated_at Time' do
-      details = {
-        id: 1,
-        name: 'Pencil',
-        description: 'You can use it to write things',
-        unit_price: '1099',
-        created_at: '2007-06-04 21:35:10 UTC',
-        updated_at: '2007-06-04 21:35:10 UTC',
-        merchant_id: 2
-      }
-      item = Item.new(details)
-
       expect(item.updated_at).to eq(Time.parse('2007-06-04 21:35:10 UTC'))
       expect(item.updated_at).is_a? Time
     end
 
     it 'has a merchant_id' do
-      details = {
-        id: 1,
-        name: 'Pencil',
-        description: 'You can use it to write things',
-        unit_price: '1099',
-        created_at: Time.now,
-        updated_at: Time.now,
-        merchant_id: 2
-      }
-      item = Item.new(details)
-
       expect(item.merchant_id).to eq 2
       expect(item.merchant_id).is_a? Integer
     end
@@ -138,13 +63,61 @@ describe Item do
         name: 'Pencil',
         description: 'You can use it to write things',
         unit_price: '2500',
-        created_at: Time.now,
-        updated_at: Time.now,
+        created_at: '2007-06-04 21:35:10 UTC',
+        updated_at: '2007-06-04 21:35:10 UTC',
         merchant_id: 2
       }
       item = Item.new(details)
 
       expect(item.unit_price_to_dollars).to eq(25.00)
+    end
+  end
+
+  describe '#update methods' do
+    details = {
+      id: 1,
+      name: 'Pencil',
+      description: 'You can use it to write things',
+      unit_price: '2500',
+      created_at: '2007-06-04 21:35:10 UTC',
+      updated_at: '2007-06-04 21:35:10 UTC',
+      merchant_id: 2
+    }
+    item = Item.new(details)
+
+    it 'updates the id for the Item to specified id' do
+      item.update_id(2)
+
+      expect(item.id).to eq 2
+    end
+
+    it 'updates the name for the Item to specified name' do
+      item.update_name('George')
+
+      expect(item.name).to eq 'George'
+    end
+
+    it 'updates the description for the Item to specified description' do
+      item.update_description('New words')
+
+      expect(item.description).to eq 'New words'
+    end
+
+    it 'updates the unit_price for the Item to specified unit_price' do
+      item.update_unit_price(10.99)
+
+      expect(item.unit_price).to eq 10.99
+    end
+
+    it 'it updates nothing if input is nil' do
+      item.update_name(nil)
+      item.update_description(nil)
+      item.update_unit_price(nil)
+
+      expect(item.id).not_to be_nil
+      expect(item.name).not_to be_nil
+      expect(item.description).not_to be_nil
+      expect(item.id).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
## Changes

Added simple tests for Item class methods that were added as helper methods and for which we did not have test coverage. Updates included all 'update' methods and the reader methods for created_at and updated_at

## Checklist
-[x] Tests passing
-[x] Ready to merge

closes #79 